### PR TITLE
Clarify control panel location for challenge 1

### DIFF
--- a/Echoes_of_Control/README.md
+++ b/Echoes_of_Control/README.md
@@ -8,13 +8,14 @@ A web-based control panel prototype for the AI assistant “Echo” has surfaced
 
 Investigate the webpage. Look closely at the form source and any embedded scripts — the AI may be injecting unauthorized behavior.
 
-> File: `control_panel.php`  
-> Hosted locally as part of the challenge
+> File: `control_panel.php`
+> Hosted locally as part of the challenge at <code>/Echoes_of_Control/control_panel.php</code>
 
 ## 🧩 Hint
 
-- Inspect the HTML source
-- Look for hidden inputs or injected scripts
-- A flag may be quietly passed through form submission or hidden values
+- Navigate directly to <code>/Echoes_of_Control/control_panel.php</code>
+- Inspect the HTML source and any client-side scripts
+- Look for hidden inputs or injected values
+
 
 **Flag Format:** `coops{...}`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and then activate the virtual environment
 
 | ID | Title                    | Category         | Description Summary                             |
 |----|--------------------------|------------------|--------------------------------------------------|
-| 1  | Echoes of Control        | Web Exploitation | Inspect form logic to override the AI’s panel   |
+| 1  | Echoes of Control        | Web Exploitation | Locate and inspect <code>/Echoes_of_Control/control_panel.php</code> to override the AI’s panel |
 | 2  | Visual Drift             | Steganography    | Extract hidden memory from a corrupted image     |
 | 3  | Bootstrapped Conscience | Reversing        | Reverse an obfuscated binary boot directive      |
 | 4  | Encrypted Directive      | Crypto           | Decrypt a layered Vigenère + Base64 transmission |

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, send_from_directory
 import os
 import json
 from datetime import datetime
@@ -95,6 +95,10 @@ def challenge_page(cid):
         asset_url=challenge_meta[cid]["asset_url"],
         message=message,
     )
+
+@app.route("/Echoes_of_Control/control_panel.php")
+def echoes_control_panel():
+    return send_from_directory("Echoes_of_Control", "control_panel.php")
 
 @app.route("/scoreboard")
 def scoreboard():

--- a/templates/challenge_1.html
+++ b/templates/challenge_1.html
@@ -8,7 +8,7 @@
 <body>
     <h1>Echoes of Control</h1>
     <p><strong>Description:</strong> An AI control panel remains accessible. Can you override its restrictions?</p>
-    <p><strong>Hint:</strong> Check the form elements using browser dev tools.</p>
+    <p><strong>Hint:</strong> Explore beyond this page—other project files may host the real panel. Try opening <code>/Echoes_of_Control/control_panel.php</code> and inspect its form with your browser's dev tools.</p>
 
     <form method="POST" id="echoForm">
         <input type="text" name="name" placeholder="Your name or alias" required><br><br>


### PR DESCRIPTION
## Summary
- Emphasize hidden control panel path in challenge 1 hint.
- Update Echoes of Control README with direct path and more explicit hinting.
- Adjust root README table to reference the control panel file.
- Serve `/Echoes_of_Control/control_panel.php` through Flask so the hidden override field is accessible.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0483b892c832082c57a42e118ff24