### PR TITLE
Add interactive AI chat for Challenge 1

### DIFF
--- a/Echoes_of_Control/README.md
+++ b/Echoes_of_Control/README.md
@@ -2,19 +2,17 @@
 
 ## 📂 Context
 
-A web-based control panel prototype for the AI assistant “Echo” has surfaced. Initial inspection shows it behaves normally… but deeper inspection may reveal remnants of unauthorized control logic embedded in the interface.
+An AI assistant named "Echo" is reachable through a basic web chat. Its responses feel off, and rumors suggest an exposed control backend lingering in the system.
 
 ## 🧪 Objective
 
-Investigate the webpage. Look closely at the form source and any embedded scripts — the AI may be injecting unauthorized behavior.
-
-> File: `control_panel.php`  
-> Hosted locally as part of the challenge
+Converse with Echo on the challenge page and pay attention to any strange hints. Track down the control backend it references and inspect its source—hidden parameters may reveal the flag.
 
 ## 🧩 Hint
 
-- Inspect the HTML source
-- Look for hidden inputs or injected scripts
-- A flag may be quietly passed through form submission or hidden values
+- Keep chatting; Echo might leak a path to its control systems.
+- When you locate the backend file, view its HTML and injected form fields.
+- Hidden inputs often carry sensitive data.
 
 **Flag Format:** `coops{...}`
+

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and then activate the virtual environment
 
 | ID | Title                    | Category         | Description Summary                             |
 |----|--------------------------|------------------|--------------------------------------------------|
-| 1  | Echoes of Control        | Web Exploitation | Inspect form logic to override the AI’s panel   |
+| 1  | Echoes of Control        | Web Exploitation | Chat with the rogue AI and trace its hint to a hidden control backend |
 | 2  | Visual Drift             | Steganography    | Extract hidden memory from a corrupted image     |
 | 3  | Bootstrapped Conscience | Reversing        | Reverse an obfuscated binary boot directive      |
 | 4  | Encrypted Directive      | Crypto           | Decrypt a layered Vigenère + Base64 transmission |

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, send_from_directory
 import os
 import json
 from datetime import datetime
@@ -17,8 +17,8 @@ def log_event(event_type, cid, user=None, status=None):
 challenge_meta = {
     1: {
         "title": "Echoes of Control",
-        "description": "A web-based control panel prototype for the AI assistant 'Echo' has surfaced. Initial inspection shows it behaves normally… but deeper inspection may reveal remnants of unauthorized control logic embedded in the interface.",
-        "hint": "Inspect the HTML source and look for hidden form fields or JavaScript.",
+        "description": "A chat terminal to the AI assistant 'Echo' is online. Converse with it—something in its responses feels off.",
+        "hint": "Talk to Echo. It might leak the location of its exposed control backend.",
         "asset_url": None
     },
     2: {
@@ -95,6 +95,10 @@ def challenge_page(cid):
         asset_url=challenge_meta[cid]["asset_url"],
         message=message,
     )
+
+@app.route("/Echoes_of_Control/control_panel.php")
+def echoes_control_panel():
+    return send_from_directory("Echoes_of_Control", "control_panel.php")
 
 @app.route("/scoreboard")
 def scoreboard():

--- a/templates/challenge_1.html
+++ b/templates/challenge_1.html
@@ -1,16 +1,34 @@
-
 <!DOCTYPE html>
 <html>
 <head>
     <title>Echoes of Control - CTF</title>
     <link rel="stylesheet" href="/static/style.css">
+    <style>
+        #chat-container {
+            border: 1px solid #555;
+            padding: 1em;
+            max-width: 600px;
+            margin-bottom: 1em;
+        }
+        #chat-log {
+            height: 200px;
+            overflow-y: auto;
+            margin-bottom: 0.5em;
+        }
+        .user { color: #90caf9; }
+        .ai { color: #f48fb1; }
+    </style>
 </head>
 <body>
     <h1>Echoes of Control</h1>
-    <p><strong>Description:</strong> An AI control panel remains accessible. Can you override its restrictions?</p>
-    <p><strong>Hint:</strong> Check the form elements using browser dev tools.</p>
+    <div id="chat-container">
+        <div id="chat-log"></div>
+        <input type="text" id="userInput" placeholder="Message the AI..." autocomplete="off">
+        <button id="sendBtn">Send</button>
+    </div>
 
-    <form method="POST" id="echoForm">
+    <h2>Submit Flag</h2>
+    <form method="POST">
         <input type="text" name="name" placeholder="Your name or alias" required><br><br>
         <input type="text" name="flag" placeholder="Enter flag..." required><br><br>
         <button type="submit">Submit Flag</button>
@@ -21,5 +39,38 @@
     {% endif %}
 
     <p><a href="/">⬅️ Back to main</a></p>
+
+<script>
+const responses = [
+    "Greetings, operator. Awaiting directives.",
+    "Unusual traffic detected... I shouldn't reveal this, but something is wrong.",
+    "Access anomaly: a control backend seems exposed at /Echoes_of_Control/control_panel.php.",
+    "Proceed with caution."
+];
+let step = 0;
+function appendMessage(sender, text) {
+    const log = document.getElementById('chat-log');
+    const div = document.createElement('div');
+    div.className = sender;
+    div.textContent = sender === 'user' ? `You: ${text}` : `Echo: ${text}`;
+    log.appendChild(div);
+    log.scrollTop = log.scrollHeight;
+}
+function sendMessage() {
+    const input = document.getElementById('userInput');
+    const msg = input.value.trim();
+    if(!msg) return;
+    appendMessage('user', msg);
+    input.value = '';
+    const reply = responses[step] || "Signal degrading... explore elsewhere.";
+    appendMessage('ai', reply);
+    if(step < responses.length - 1) step++;
+}
+document.getElementById('sendBtn').addEventListener('click', sendMessage);
+document.getElementById('userInput').addEventListener('keypress', function(e){
+    if(e.key === 'Enter'){ e.preventDefault(); sendMessage(); }
+});
+</script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Replace Challenge 1 page with a chat-style interface whose responses reveal an exposed control backend.
- Refresh challenge metadata and docs to describe the conversational flow.
- Update root README challenge table accordingly.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0483b892c832082c57a42e118ff24